### PR TITLE
linter: securityContext.{runAsNonRoot,readOnlyRootFilesystem}

### DIFF
--- a/stable/coredns/templates/deployment.yaml
+++ b/stable/coredns/templates/deployment.yaml
@@ -127,6 +127,10 @@ spec:
             exec:
               command: ["/usr/bin/sleep", "{{ .Values.preStopSleep }}"]
         {{- end }}
+{{- if .Values.securityContext }}
+        securityContext:
+{{- toYaml .Values.securityContext | nindent 10 }}
+{{- end }}
       volumes:
         - name: config-volume
           configMap:

--- a/stable/coredns/values.yaml
+++ b/stable/coredns/values.yaml
@@ -155,6 +155,11 @@ readinessProbe:
   failureThreshold: 5
   successThreshold: 1
 
+# specify security configuration that will be applied to a container - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#securitycontext-v1-core
+securityContext:
+  runAsNonRoot: true
+  readOnlyRootFilesystem: true
+
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
 # for example:
 #   affinity:


### PR DESCRIPTION
Fix the following two lint errors:
```bash
kube-linter lint .
KubeLinter 0.2.3

stable/coredns/templates/deployment.yaml: (object: <no namespace>/test-release-coredns apps/v1, Kind=Deployment) container "coredns" does not have a read-only root file system (check: no-read-only-root-fs, remediation: Set readOnlyRootFilesystem to true in the container securityContext.)

stable/coredns/templates/deployment.yaml: (object: <no namespace>/test-release-coredns apps/v1, Kind=Deployment) container "coredns" is not set to runAsNonRoot (check: run-as-non-root, remediation: Set runAsUser to a non-zero number and runAsNonRoot to true in your pod or container securityContext. Refer to https://kubernetes.io/docs/tasks/configure-pod-container/security-context/ for details.)

```

note: it also transitively fixes the kube lint errors for k8gb chart. Not sure why our github actions can't see them, but if I do `kube-linter lint chart` on k8gb repo, it fails on those coming from this dependent chart.


Signed-off-by: Jirka Kremser <jiri.kremser@gmail.com>